### PR TITLE
Add styles

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,6 +8,6 @@
  * You're free to add application-wide styles to this file and they'll appear at the top of the
  * compiled file, but it's generally better to create a new file per style scope.
  *
+ *= require ./spree_admin
  *= require_self
- *= require_tree .
  */

--- a/app/assets/stylesheets/globals/_functions.scss
+++ b/app/assets/stylesheets/globals/_functions.scss
@@ -1,0 +1,25 @@
+// Make color very close to white
+@function very-light($color, $adjust: 3){  
+  @if type-of($adjust) == 'number' and $adjust > 0 {
+    @for $i from 0 through 100 {
+      @if lighten($color, $i) == white and ($i - $adjust) > $adjust {
+        @return lighten($color, $i - $adjust);
+      }
+    }
+  }
+  @else {
+    @debug "Please correct $adjust value. It should be number and larger then 0. Currently it is '#{type-of($adjust)}' with value '#{$adjust}'"
+  }
+};
+
+// Quick fix for dynamic variables missing in SASS
+@function get-value($prop, $val, $search) {
+  $n1: index($prop, $search);
+  $n2: index($val, $search);
+
+  @if($n1) {
+    @return nth($val, $n1);
+  } @else {
+    @return nth($prop, $n2);
+  }
+}

--- a/app/assets/stylesheets/globals/_mixins.scss
+++ b/app/assets/stylesheets/globals/_mixins.scss
@@ -1,0 +1,25 @@
+//************************************************************************//
+// Default: Webkit, moz, spec
+// Example: @include prefixer(border-radius, $radii, $o: true);
+//
+// Source : https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/css3/_prefixer.scss
+//************************************************************************//
+@mixin prefixer ($property, $value,
+                 $webkit: true,
+                    $moz: true,
+                     $ms: false,
+                      $o: false,
+                   $spec: true) {
+  @if $webkit { -webkit-#{$property}: $value; }
+  @if $moz    {    -moz-#{$property}: $value; }
+  @if $ms     {     -ms-#{$property}: $value; }
+  @if $o      {      -o-#{$property}: $value; }
+  @if $spec   {         #{$property}: $value; }
+}
+
+//************************************************************************//
+// Source : https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/css3/_border-radius.scss
+//************************************************************************//
+@mixin border-radius ($radii) {
+  @include prefixer(border-radius, $radii, webkit, moz, ms, o);
+}

--- a/app/assets/stylesheets/globals/_variables.scss
+++ b/app/assets/stylesheets/globals/_variables.scss
@@ -1,0 +1,140 @@
+// -------------------------------------------------------------
+//   Variables used in all other files
+//--------------------------------------------------------------
+
+// Fonts
+//--------------------------------------------------------------
+$base-font-family: "Open Sans", "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+
+// Colors
+//--------------------------------------------------------------
+
+// Basic color palette for admin
+$color-1:                        #FFFFFF !default;    // White
+$color-2:                        #9FC820 !default;    // Green
+$color-3:                        #5498DA !default;    // Light Blue
+$color-4:                        #6788A2 !default;    // Dark Blue
+$color-5:                        #C60F13 !default;    // Red
+$color-6:                        #FF9300 !default;    // Yellow
+
+// Body base colors
+$color-body-bg:                  $color-1 !default;
+$color-body-text:                $color-4 !default;
+$color-headers:                  $color-4 !default;
+$color-link:                     $color-3 !default;
+$color-link-hover:               $color-2 !default;
+$color-link-active:              $color-2 !default;
+$color-link-focus:               $color-2 !default;
+$color-link-visited:             $color-3 !default;
+$color-border:                   very-light($color-3, 12) !default;
+
+// Basic flash colors
+$color-success:                  $color-2 !default;
+$color-notice:                   $color-6 !default;
+$color-error:                    $color-5 !default;
+
+// Table colors
+$color-tbl-odd:                  $color-1 !default;
+$color-tbl-even:                 very-light($color-3, 4) !default;
+$color-tbl-thead:                very-light($color-3, 4) !default;
+
+// Button colors
+$color-btn-bg:                   $color-3 !default;
+$color-btn-text:                 $color-1 !default;
+$color-btn-hover-bg:             $color-2 !default;
+$color-btn-hover-text:           $color-1 !default;
+
+// Actions colors
+$color-action-edit-bg:           very-light($color-success, 5  ) !default;
+$color-action-edit-brd:          very-light($color-success, 20 ) !default;
+$color-action-clone-bg:          very-light($color-notice,  5  ) !default;
+$color-action-clone-brd:         very-light($color-notice,  15 ) !default;
+$color-action-remove-bg:         very-light($color-error,   5  ) !default;
+$color-action-remove-brd:        very-light($color-error,   10 ) !default;
+$color-action-void-bg:           very-light($color-error,   10 ) !default;
+$color-action-void-brd:          very-light($color-error,   20 ) !default;
+$color-action-capture-bg:        very-light($color-success, 5  ) !default;
+$color-action-capture-brd:       very-light($color-success, 20 ) !default;
+$color-action-mail-bg:           very-light($color-success, 5  ) !default;
+$color-action-mail-brd:          very-light($color-success, 20 ) !default;
+
+// Select2 select field colors
+$color-sel-bg:                   $color-3 !default;
+$color-sel-text:                 $color-1 !default;
+$color-sel-hover-bg:             $color-2 !default;
+$color-sel-hover-text:           $color-1 !default;
+
+// Text inputs colors
+$color-txt-brd:                  $color-border !default;
+$color-txt-text:                 $color-3 !default;
+$color-txt-hover-brd:            $color-2 !default;
+
+// States label colors
+$color-ste-complete-bg:          $color-success !default;
+$color-ste-complete-text:        $color-1 !default;
+$color-ste-completed-bg:         $color-success !default;
+$color-ste-completed-text:       $color-1 !default;
+$color-ste-sold-bg:              $color-success !default;
+$color-ste-sold-text:            $color-1 !default;
+$color-ste-pending-bg:           $color-notice !default;
+$color-ste-pending-text:         $color-1 !default;
+$color-ste-paid-bg:              $color-success !default;
+$color-ste-paid-text:            $color-1 !default;
+$color-ste-shipped-bg:           $color-success !default;
+$color-ste-shipped-text:         $color-1 !default;
+$color-ste-balance_due-bg:       $color-notice !default;
+$color-ste-balance_due-text:     $color-1 !default;
+$color-ste-backorder-bg:         $color-notice !default;
+$color-ste-backorder-text:       $color-1 !default;
+$color-ste-none-bg:              $color-error !default;
+$color-ste-none-text:            $color-1 !default;
+$color-ste-ready-bg:             $color-success !default;
+$color-ste-ready-text:           $color-1 !default;
+$color-ste-void-bg:              $color-error !default;
+$color-ste-void-text:            $color-1 !default;
+$color-ste-canceled-bg:          $color-error !default;
+$color-ste-canceled-text:        $color-1 !default;
+$color-ste-address-bg:           $color-error !default;
+$color-ste-address-text:         $color-1 !default;
+$color-ste-checkout-bg:          $color-notice !default;
+$color-ste-checkout-text:        $color-1 !default;
+$color-ste-cart-bg:              $color-notice !default;
+$color-ste-cart-text:            $color-1 !default;
+$color-ste-payment-bg:           $color-error !default;
+$color-ste-payment-text:         $color-1 !default;
+$color-ste-delivery-bg:          $color-success !default;
+$color-ste-delivery-text:        $color-1 !default;
+$color-ste-confirm-bg:           $color-error !default;
+$color-ste-confirm-text:         $color-1 !default;
+$color-ste-backordered-bg:       $color-notice !default;
+$color-ste-backordered-text:     $color-1 !default;
+$color-ste-credit_owed-bg:       $color-success !default;
+$color-ste-credit_owed-text:     $color-1 !default;
+$color-ste-awaiting_return-bg:   $color-notice !default;;
+$color-ste-awaiting_return-text: $color-1 !default;;
+
+// Avaliable states
+$states:                         completed,                 complete,                 sold,                 pending,                 paid,                 shipped,                 balance_due,                 backorder,                 checkout,                 cart,                 address,                 delivery,                 payment,                 confirm,                 canceled,                 ready,                 void,                 backordered,                 credit_owed,                 awaiting_return !default;
+$states-bg-colors:               $color-ste-completed-bg,   $color-ste-complete-bg,   $color-ste-sold-bg,   $color-ste-pending-bg,   $color-ste-paid-bg,   $color-ste-shipped-bg,   $color-ste-balance_due-bg,   $color-ste-backorder-bg,   $color-ste-checkout-bg,   $color-ste-cart-bg,   $color-ste-address-bg,   $color-ste-delivery-bg,   $color-ste-payment-bg,   $color-ste-confirm-bg,   $color-ste-canceled-bg,   $color-ste-ready-bg,   $color-ste-void-bg,   $color-ste-backordered-bg,   $color-ste-credit_owed-bg,   $color-ste-awaiting_return-bg !default;
+$states-text-colors:             $color-ste-completed-text, $color-ste-complete-text, $color-ste-sold-text, $color-ste-pending-text, $color-ste-paid-text, $color-ste-shipped-text, $color-ste-balance_due-text, $color-ste-backorder-text, $color-ste-checkout-text, $color-ste-cart-text, $color-ste-address-text, $color-ste-delivery-text, $color-ste-payment-text, $color-ste-confirm-text, $color-ste-canceled-text, $color-ste-ready-text, $color-ste-void-text, $color-ste-backordered-text, $color-ste-credit_owed-text, $color-ste-awaiting_return-text !default;
+
+// Avaliable actions
+$actions:                        edit,                   clone,                   remove,                   void,                   capture,                   mail  !default;
+$actions-bg-colors:              $color-action-edit-bg,  $color-action-clone-bg,  $color-action-remove-bg,  $color-action-void-bg,  $color-action-capture-bg,  $color-action-mail-bg  !default;
+$actions-brd-colors:             $color-action-edit-brd, $color-action-clone-brd, $color-action-remove-brd, $color-action-void-brd, $color-action-capture-brd, $color-action-mail-brd !default;
+
+// Sizes
+//--------------------------------------------------------------
+$body-font-size:                 13px !default;
+
+$h6-size:                        $body-font-size + 2 !default;
+$h5-size:                        $h6-size + 2 !default;
+$h4-size:                        $h5-size + 2 !default;
+$h3-size:                        $h4-size + 2 !default;
+$h2-size:                        $h3-size + 2 !default;
+$h1-size:                        $h2-size + 2 !default;
+
+$border-radius:                  3px !default;
+
+$font-weight-bold:               600 !default;
+$font-weight-normal:             400 !default;

--- a/app/assets/stylesheets/globals/_variables_override.scss
+++ b/app/assets/stylesheets/globals/_variables_override.scss
@@ -1,0 +1,7 @@
+/*--------------------------------------------------------- 
+  Empty file to override variables in user applications.
+
+  To set your own colors, sizes or fonts just override this 
+  file in you're application and set valiables according to
+  globals/_variables.scss file.
+  --------------------------------------------------------- */

--- a/app/assets/stylesheets/plugins/font-awesome.scss
+++ b/app/assets/stylesheets/plugins/font-awesome.scss
@@ -1,0 +1,303 @@
+/*  Font Awesome
+    the iconic font designed for use with Twitter Bootstrap
+    -------------------------------------------------------
+    The full suite of pictographic icons, examples, and documentation
+    can be found at: http://fortawesome.github.com/Font-Awesome/
+
+    License
+    -------------------------------------------------------
+    The Font Awesome webfont, CSS, and LESS files are licensed under CC BY 3.0:
+    http://creativecommons.org/licenses/by/3.0/ A mention of
+    'Font Awesome - http://fortawesome.github.com/Font-Awesome' in human-readable
+    source code is considered acceptable attribution (most common on the web).
+    If human readable source code is not available to the end user, a mention in
+    an 'About' or 'Credits' screen is considered acceptable (most common in desktop
+    or mobile software).
+
+    Contact
+    -------------------------------------------------------
+    Email: dave@davegandy.com
+    Twitter: http://twitter.com/fortaweso_me
+    Work: http://lemonwi.se co-founder
+
+    */
+@font-face {
+  font-family: "FontAwesome";
+  src: url('/assets/fontawesome-webfont.eot');
+  src: url('/assets/fontawesome-webfont.eot?#iefix') format('eot'), url('/assets/fontawesome-webfont.woff') format('woff'), url('/assets/fontawesome-webfont.ttf') format('truetype'), url('/assets/fontawesome-webfont.svg#FontAwesome') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+
+/*  Font Awesome styles
+    ------------------------------------------------------- */
+[class^="icon-"]:before, [class*=" icon-"]:before {
+  font-family: FontAwesome;
+  font-weight: normal;
+  font-style: normal;
+  display: inline-block;
+  text-decoration: inherit;
+}
+a [class^="icon-"], a [class*=" icon-"] {
+  display: inline-block;
+  text-decoration: inherit;
+}
+/* makes the font 33% larger relative to the icon container */
+.icon-large:before {
+  vertical-align: top;
+  font-size: 1.3333333333333333em;
+}
+.btn [class^="icon-"], .btn [class*=" icon-"] {
+  /* keeps button heights with and without icons the same */
+
+  line-height: .9em;
+}
+li [class^="icon-"], li [class*=" icon-"] {
+  display: inline-block;
+  width: 1.25em;
+  text-align: center;
+}
+li .icon-large[class^="icon-"], li .icon-large[class*=" icon-"] {
+  /* 1.5 increased font size for icon-large * 1.25 width */
+
+  width: 1.875em;
+}
+li[class^="icon-"], li[class*=" icon-"] {
+  margin-left: 0;
+  list-style-type: none;
+}
+li[class^="icon-"]:before, li[class*=" icon-"]:before {
+  text-indent: -2em;
+  text-align: center;
+}
+li[class^="icon-"].icon-large:before, li[class*=" icon-"].icon-large:before {
+  text-indent: -1.3333333333333333em;
+}
+/*  Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
+    readers do not read off random characters that represent icons */
+.icon-glass:before                { content: "\f000"; }
+.icon-music:before                { content: "\f001"; }
+.icon-search:before               { content: "\f002"; }
+.icon-envelope:before             { content: "\f003"; }
+.icon-heart:before                { content: "\f004"; }
+.icon-star:before                 { content: "\f005"; }
+.icon-star-empty:before           { content: "\f006"; }
+.icon-user:before                 { content: "\f007"; }
+.icon-film:before                 { content: "\f008"; }
+.icon-th-large:before             { content: "\f009"; }
+.icon-th:before                   { content: "\f00a"; }
+.icon-th-list:before              { content: "\f00b"; }
+.icon-ok:before                   { content: "\f00c"; }
+.icon-remove:before               { content: "\f00d"; }
+.icon-zoom-in:before              { content: "\f00e"; }
+
+.icon-zoom-out:before             { content: "\f010"; }
+.icon-off:before                  { content: "\f011"; }
+.icon-signal:before               { content: "\f012"; }
+.icon-cog:before                  { content: "\f013"; }
+.icon-trash:before                { content: "\f014"; }
+.icon-home:before                 { content: "\f015"; }
+.icon-file:before                 { content: "\f016"; }
+.icon-time:before                 { content: "\f017"; }
+.icon-road:before                 { content: "\f018"; }
+.icon-download-alt:before         { content: "\f019"; }
+.icon-download:before             { content: "\f01a"; }
+.icon-upload:before               { content: "\f01b"; }
+.icon-inbox:before                { content: "\f01c"; }
+.icon-play-circle:before          { content: "\f01d"; }
+.icon-repeat:before               { content: "\f01e"; }
+
+/* \f020 doesn't work in Safari. all shifted one down */
+.icon-refresh:before              { content: "\f021"; }
+.icon-list-alt:before             { content: "\f022"; }
+.icon-lock:before                 { content: "\f023"; }
+.icon-flag:before                 { content: "\f024"; }
+.icon-headphones:before           { content: "\f025"; }
+.icon-volume-off:before           { content: "\f026"; }
+.icon-volume-down:before          { content: "\f027"; }
+.icon-volume-up:before            { content: "\f028"; }
+.icon-qrcode:before               { content: "\f029"; }
+.icon-barcode:before              { content: "\f02a"; }
+.icon-tag:before                  { content: "\f02b"; }
+.icon-tags:before                 { content: "\f02c"; }
+.icon-book:before                 { content: "\f02d"; }
+.icon-bookmark:before             { content: "\f02e"; }
+.icon-print:before                { content: "\f02f"; }
+
+.icon-camera:before               { content: "\f030"; }
+.icon-font:before                 { content: "\f031"; }
+.icon-bold:before                 { content: "\f032"; }
+.icon-italic:before               { content: "\f033"; }
+.icon-text-height:before          { content: "\f034"; }
+.icon-text-width:before           { content: "\f035"; }
+.icon-align-left:before           { content: "\f036"; }
+.icon-align-center:before         { content: "\f037"; }
+.icon-align-right:before          { content: "\f038"; }
+.icon-align-justify:before        { content: "\f039"; }
+.icon-list:before                 { content: "\f03a"; }
+.icon-indent-left:before          { content: "\f03b"; }
+.icon-indent-right:before         { content: "\f03c"; }
+.icon-facetime-video:before       { content: "\f03d"; }
+.icon-picture:before              { content: "\f03e"; }
+
+.icon-pencil:before               { content: "\f040"; }
+.icon-map-marker:before           { content: "\f041"; }
+.icon-adjust:before               { content: "\f042"; }
+.icon-tint:before                 { content: "\f043"; }
+.icon-edit:before                 { content: "\f044"; }
+.icon-share:before                { content: "\f045"; }
+.icon-check:before                { content: "\f046"; }
+.icon-move:before                 { content: "\f047"; }
+.icon-step-backward:before        { content: "\f048"; }
+.icon-fast-backward:before        { content: "\f049"; }
+.icon-backward:before             { content: "\f04a"; }
+.icon-play:before                 { content: "\f04b"; }
+.icon-pause:before                { content: "\f04c"; }
+.icon-stop:before                 { content: "\f04d"; }
+.icon-forward:before              { content: "\f04e"; }
+
+.icon-fast-forward:before         { content: "\f050"; }
+.icon-step-forward:before         { content: "\f051"; }
+.icon-eject:before                { content: "\f052"; }
+.icon-chevron-left:before         { content: "\f053"; }
+.icon-chevron-right:before        { content: "\f054"; }
+.icon-plus-sign:before            { content: "\f055"; }
+.icon-minus-sign:before           { content: "\f056"; }
+.icon-remove-sign:before          { content: "\f057"; }
+.icon-ok-sign:before              { content: "\f058"; }
+.icon-question-sign:before        { content: "\f059"; }
+.icon-info-sign:before            { content: "\f05a"; }
+.icon-screenshot:before           { content: "\f05b"; }
+.icon-remove-circle:before        { content: "\f05c"; }
+.icon-ok-circle:before            { content: "\f05d"; }
+.icon-ban-circle:before           { content: "\f05e"; }
+
+.icon-arrow-left:before           { content: "\f060"; }
+.icon-arrow-right:before          { content: "\f061"; }
+.icon-arrow-up:before             { content: "\f062"; }
+.icon-arrow-down:before           { content: "\f063"; }
+.icon-share-alt:before            { content: "\f064"; }
+.icon-resize-full:before          { content: "\f065"; }
+.icon-resize-small:before         { content: "\f066"; }
+.icon-plus:before                 { content: "\f067"; }
+.icon-minus:before                { content: "\f068"; }
+.icon-asterisk:before             { content: "\f069"; }
+.icon-exclamation-sign:before     { content: "\f06a"; }
+.icon-gift:before                 { content: "\f06b"; }
+.icon-leaf:before                 { content: "\f06c"; }
+.icon-fire:before                 { content: "\f06d"; }
+.icon-eye-open:before             { content: "\f06e"; }
+
+.icon-eye-close:before            { content: "\f070"; }
+.icon-warning-sign:before         { content: "\f071"; }
+.icon-plane:before                { content: "\f072"; }
+.icon-calendar:before             { content: "\f073"; }
+.icon-random:before               { content: "\f074"; }
+.icon-comment:before              { content: "\f075"; }
+.icon-magnet:before               { content: "\f076"; }
+.icon-chevron-up:before           { content: "\f077"; }
+.icon-chevron-down:before         { content: "\f078"; }
+.icon-retweet:before              { content: "\f079"; }
+.icon-shopping-cart:before        { content: "\f07a"; }
+.icon-folder-close:before         { content: "\f07b"; }
+.icon-folder-open:before          { content: "\f07c"; }
+.icon-resize-vertical:before      { content: "\f07d"; }
+.icon-resize-horizontal:before    { content: "\f07e"; }
+
+.icon-bar-chart:before            { content: "\f080"; }
+.icon-twitter-sign:before         { content: "\f081"; }
+.icon-facebook-sign:before        { content: "\f082"; }
+.icon-camera-retro:before         { content: "\f083"; }
+.icon-key:before                  { content: "\f084"; }
+.icon-cogs:before                 { content: "\f085"; }
+.icon-comments:before             { content: "\f086"; }
+.icon-thumbs-up:before            { content: "\f087"; }
+.icon-thumbs-down:before          { content: "\f088"; }
+.icon-star-half:before            { content: "\f089"; }
+.icon-heart-empty:before          { content: "\f08a"; }
+.icon-signout:before              { content: "\f08b"; }
+.icon-linkedin-sign:before        { content: "\f08c"; }
+.icon-pushpin:before              { content: "\f08d"; }
+.icon-external-link:before        { content: "\f08e"; }
+
+.icon-signin:before               { content: "\f090"; }
+.icon-trophy:before               { content: "\f091"; }
+.icon-github-sign:before          { content: "\f092"; }
+.icon-upload-alt:before           { content: "\f093"; }
+.icon-lemon:before                { content: "\f094"; }
+.icon-phone:before                { content: "\f095"; }
+.icon-check-empty:before          { content: "\f096"; }
+.icon-bookmark-empty:before       { content: "\f097"; }
+.icon-phone-sign:before           { content: "\f098"; }
+.icon-twitter:before              { content: "\f099"; }
+.icon-facebook:before             { content: "\f09a"; }
+.icon-github:before               { content: "\f09b"; }
+.icon-unlock:before               { content: "\f09c"; }
+.icon-credit-card:before          { content: "\f09d"; }
+.icon-rss:before                  { content: "\f09e"; }
+
+.icon-hdd:before                  { content: "\f0a0"; }
+.icon-bullhorn:before             { content: "\f0a1"; }
+.icon-bell:before                 { content: "\f0a2"; }
+.icon-certificate:before          { content: "\f0a3"; }
+.icon-hand-right:before           { content: "\f0a4"; }
+.icon-hand-left:before            { content: "\f0a5"; }
+.icon-hand-up:before              { content: "\f0a6"; }
+.icon-hand-down:before            { content: "\f0a7"; }
+.icon-circle-arrow-left:before    { content: "\f0a8"; }
+.icon-circle-arrow-right:before   { content: "\f0a9"; }
+.icon-circle-arrow-up:before      { content: "\f0aa"; }
+.icon-circle-arrow-down:before    { content: "\f0ab"; }
+.icon-globe:before                { content: "\f0ac"; }
+.icon-wrench:before               { content: "\f0ad"; }
+.icon-tasks:before                { content: "\f0ae"; }
+
+.icon-filter:before               { content: "\f0b0"; }
+.icon-briefcase:before            { content: "\f0b1"; }
+.icon-fullscreen:before           { content: "\f0b2"; }
+
+.icon-group:before                { content: "\f0c0"; }
+.icon-link:before                 { content: "\f0c1"; }
+.icon-cloud:before                { content: "\f0c2"; }
+.icon-beaker:before               { content: "\f0c3"; }
+.icon-cut:before                  { content: "\f0c4"; }
+.icon-copy:before                 { content: "\f0c5"; }
+.icon-paper-clip:before           { content: "\f0c6"; }
+.icon-save:before                 { content: "\f0c7"; }
+.icon-sign-blank:before           { content: "\f0c8"; }
+.icon-reorder:before              { content: "\f0c9"; }
+.icon-list-ul:before              { content: "\f0ca"; }
+.icon-list-ol:before              { content: "\f0cb"; }
+.icon-strikethrough:before        { content: "\f0cc"; }
+.icon-underline:before            { content: "\f0cd"; }
+.icon-table:before                { content: "\f0ce"; }
+
+.icon-magic:before                { content: "\f0d0"; }
+.icon-truck:before                { content: "\f0d1"; }
+.icon-pinterest:before            { content: "\f0d2"; }
+.icon-pinterest-sign:before       { content: "\f0d3"; }
+.icon-google-plus-sign:before     { content: "\f0d4"; }
+.icon-google-plus:before          { content: "\f0d5"; }
+.icon-money:before                { content: "\f0d6"; }
+.icon-caret-down:before           { content: "\f0d7"; }
+.icon-caret-up:before             { content: "\f0d8"; }
+.icon-caret-left:before           { content: "\f0d9"; }
+.icon-caret-right:before          { content: "\f0da"; }
+.icon-columns:before              { content: "\f0db"; }
+.icon-sort:before                 { content: "\f0dc"; }
+.icon-sort-down:before            { content: "\f0dd"; }
+.icon-sort-up:before              { content: "\f0de"; }
+
+.icon-envelope-alt:before         { content: "\f0e0"; }
+.icon-linkedin:before             { content: "\f0e1"; }
+.icon-undo:before                 { content: "\f0e2"; }
+.icon-legal:before                { content: "\f0e3"; }
+.icon-dashboard:before            { content: "\f0e4"; }
+.icon-comment-alt:before          { content: "\f0e5"; }
+.icon-comments-alt:before         { content: "\f0e6"; }
+.icon-bolt:before                 { content: "\f0e7"; }
+.icon-sitemap:before              { content: "\f0e8"; }
+.icon-umbrella:before             { content: "\f0e9"; }
+.icon-paste:before                { content: "\f0ea"; }
+
+.icon-user-md:before              { content: "\f200"; }

--- a/app/assets/stylesheets/shared/_icons.scss
+++ b/app/assets/stylesheets/shared/_icons.scss
@@ -1,0 +1,21 @@
+// Some fixes for fontwesome stylesheets
+[class^="icon-"], [class*=" icon-"] {
+  &.button, &.icon_link {
+    width: auto;
+
+    &:before {
+      padding-right: 5px;
+    }
+  }
+}
+
+[class^="icon-"]:before, [class*=" icon-"]:before {
+  -webkit-font-smoothing: antialiased;
+}
+.icon-email:before    { @extend .icon-envelope:before }
+.icon-resume:before   { @extend .icon-refresh:before  }
+
+.icon-cancel:before, 
+.icon-void:before     { @extend .icon-remove:before   }
+
+.icon-capture:before  { @extend .icon-ok:before       }

--- a/app/assets/stylesheets/shared/_layout.scss
+++ b/app/assets/stylesheets/shared/_layout.scss
@@ -1,0 +1,85 @@
+// Basics
+//---------------------------------------------------
+* {
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+          box-sizing: border-box;
+}
+
+// Helpers
+.block-table {
+  display: table;
+  width: 100%;
+
+  .table-cell {
+    display: table-cell;
+    vertical-align: middle;
+    padding: 0 10px;
+
+    &:first-child {
+      padding-left: 0;
+    }
+    &:last-child {
+      padding-right: 0;
+    }
+  }
+}
+
+// For block grids
+.frameless {
+  margin-left: -10px;
+  margin-right: -10px;
+}
+
+// Header
+//---------------------------------------------------
+#header {
+  background-color: $color-1;
+  padding: 5px 0;
+}
+
+#logo { height: 40px }
+
+[data-hook="admin-title"] { font-size: 14px }
+
+.page-title {
+  i {
+    color: $color-2;
+  }
+}
+
+// Content
+//---------------------------------------------------
+#content {
+  background-color: $color-1;
+  position: relative;
+  z-index: 0;
+  padding: 0;
+  margin-top: 15px;
+}
+
+#content-header {
+  padding: 15px 0;
+  background-color: very-light($color-3, 4);
+  border-bottom: 1px solid $color-border;
+
+  .page-title {
+    font-size: 20px;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page-actions {
+    text-align: right;
+
+    .button {
+      font-size: 85%;
+    }
+  }
+}
+
+// Footer
+//---------------------------------------------------
+#footer {
+  margin-top: 15px;
+  border-top: 1px solid $color-border;
+  padding: 10px 0;
+}

--- a/app/assets/stylesheets/shared/_tables.scss
+++ b/app/assets/stylesheets/shared/_tables.scss
@@ -1,0 +1,180 @@
+table {
+  width: 100%;
+  margin-bottom: 15px;
+  border-collapse: separate;
+
+  th, td {
+    padding: 15px 10px;
+    border-right: 1px solid $color-border;
+    border-bottom: 1px solid $color-border;
+    vertical-align: middle;
+    text-overflow: ellipsis;
+
+    img {
+      border: 1px solid transparent;
+    }
+
+    &:first-child {      
+      border-left: 1px solid $color-border;
+    }
+
+    &.actions {
+      background-color: transparent;
+      border: none !important;
+      text-align: center;
+
+      span.text {
+        font-size: $body-font-size;
+      }
+
+      [class*='icon-'].no-text {
+        font-size: 120%;
+        background-color: very-light($color-3);
+        border: 1px solid $color-border;
+        border-radius: 15px;
+        width: 29px;
+        height: 29px;
+        display: inline-block;
+        padding-top: 2px;
+
+        &:before {
+          text-align: center !important;
+          width: 27px;
+          display: inline-block;
+        }
+
+        &:hover {
+          border-color: transparent;
+        }
+      }
+      .icon-envelope-alt {
+        color: $color-link;
+        padding-left: 0px;
+
+        &:hover {
+          background-color: $color-3;
+          color: $color-1;
+        }
+      }
+      .icon-trash:hover, .icon-void:hover {
+        background-color: $color-error;
+        color: $color-1;
+      }    
+      .icon-edit:hover, .icon-capture:hover {
+        background-color: $color-success;
+        color: $color-1;
+      }
+      .icon-copy:hover {
+        background-color: $color-notice;
+        color: $color-1;
+      }
+    }
+
+    input[type="number"],
+    input[type="text"] {
+      width: 100%;
+    }
+
+    &.no-border {
+      border-right: none;
+    }
+
+    .handle {
+      @extend [class^="icon-"]:before;
+      @extend .icon-reorder !optional;
+      cursor: move;
+    }
+
+  }
+
+  &.no-borders {
+    td, th {
+      border: none !important;
+    }
+
+  }
+
+  thead {
+    th {
+      padding: 10px;
+      border-top: 1px solid $color-border;
+      border-bottom: none;
+      background-color: $color-tbl-thead;
+      text-transform: uppercase;
+      font-size: 85%;
+      font-weight: $font-weight-bold;
+    }
+  }
+
+  tbody {    
+    tr {
+      &:first-child td {
+        border-top: 1px solid $color-border;
+      }
+      &.even td {
+        background-color: $color-tbl-even;
+
+        img {
+          border: 1px solid very-light($color-3, 6);
+        }
+      }
+
+      &:hover td {
+        background-color: very-light($color-3, 5);
+
+        img {
+          border: 1px solid $color-border;
+        }
+      }
+
+      &.deleted td {
+        background-color: very-light($color-error, 6);
+        border-color: very-light($color-error, 15);
+      }
+
+      &.ui-sortable-placeholder td {
+        border: 1px solid $color-2 !important;
+        visibility: visible !important;
+
+        &.actions {
+          background-color: transparent;
+          border-right: none !important;
+          border-top: none !important;
+          border-bottom: none !important;
+          border-left: 1px solid $color-2 !important;
+        }
+      }
+
+      &.ui-sortable-helper {
+        width: 100%;
+
+        td {
+          background-color: lighten($color-3, 33);
+          border-bottom: 1px solid $color-border;          
+
+          &.actions {
+            display: none;
+          }
+        }
+      }
+    }
+
+    &.no-border-top tr:first-child td {
+      border-top: none;
+    }
+
+    &.grand-total {
+      td {
+        border-color: $color-2 !important;
+        text-transform: uppercase;
+        font-size: 110%;
+        font-weight: 600;
+        background-color: lighten($color-2, 50);
+      }
+      .total {
+        background-color: $color-2;
+        color: $color-1;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/shared/_typography.scss
+++ b/app/assets/stylesheets/shared/_typography.scss
@@ -1,0 +1,132 @@
+// Base
+//--------------------------------------------------------------
+body, div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; font-size: 13px; }
+
+body {
+  font-family: $base-font-family;
+  font-size: $body-font-size;
+  font-weight: 400;
+  color: $color-body-text;
+  text-rendering: optimizeLegibility;
+}
+
+hr {
+  border-top: 1px solid $color-border;
+  border-bottom: 1px solid white;
+  border-left: none;
+}
+
+strong, b {
+  font-weight: 600;
+}
+
+// links
+//--------------------------------------------------------------
+a {
+  color: $color-link;
+  text-decoration: none;
+  line-height: inherit;
+
+  &, &:hover, &:active, &:visited, &:focus {
+    outline: none;
+  }
+
+  &:visited {
+    color: $color-link-visited;
+  }
+  &:focus {
+    color: $color-link-focus;
+  }
+  &:active {
+    color: $color-link-active;
+  }
+  &:hover {
+    color: $color-link-hover;
+  }
+}
+
+// Headings
+//--------------------------------------------------------------
+
+h1,h2,h3,h4,h5,h6 {
+  font-weight: 600;
+  color: $color-headers;
+  line-height: 1.1;
+}
+
+h1 { font-size: $h1-size; line-height: $h1-size + 6 }
+h2 { font-size: $h2-size; line-height: $h1-size + 4 }
+h3 { font-size: $h3-size; line-height: $h1-size + 2 }
+h4 { font-size: $h4-size; line-height: $h1-size }
+h5 { font-size: $h5-size; line-height: $h1-size }
+h6 { font-size: $h6-size; line-height: $h1-size }
+
+
+// Lists
+//--------------------------------------------------------------
+ul {
+  &.inline-menu {
+    li {
+      display: inline-block;
+    }
+  }
+  &.fields {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+}
+
+dl {
+  width: 100%;
+  overflow: hidden;
+  margin: 5px 0;
+  color: lighten($color-body-text, 15);
+
+  dt, dd {
+    float: left;
+    line-height: 16px;
+    padding: 5px;
+    text-align: justify;
+  }
+
+  dt {
+    width: 40%;
+    font-weight: 600;
+    padding-left: 0;
+    text-transform: uppercase;
+    font-size: 85%;
+  }
+
+  dd {
+    width: 60%;
+    padding-right: 0;
+  }
+
+  dd:after {
+    content: '';
+    clear: both;
+  }
+
+}
+
+// Helpers
+.align-center  { text-align: center  }
+.align-right   { text-align: right   }
+.align-left    { text-align: left    }
+.align-justify { text-align: justify }
+
+.uppercase     { text-transform: uppercase }
+
+.green  { color: $color-2 }
+.blue   { color: $color-3 }
+.red    { color: $color-5 }
+.yellow { color: $color-6 }
+
+.no-objects-found {
+  text-align: center;
+  font-size: 120%;
+  text-transform: uppercase;
+  padding: 40px 0px;
+  color: lighten($color-body-text, 15);
+}

--- a/app/assets/stylesheets/spree_admin.scss
+++ b/app/assets/stylesheets/spree_admin.scss
@@ -1,3 +1,4 @@
+// TODO: Use them from the gem instead of copying them
 @import 'globals/functions';
 @import 'globals/variables_override';
 @import 'globals/variables';

--- a/app/assets/stylesheets/spree_admin.scss
+++ b/app/assets/stylesheets/spree_admin.scss
@@ -1,0 +1,10 @@
+// @import 'globals/functions';
+// @import 'globals/variables_override';
+@import 'globals/variables';
+// @import 'globals/mixins';
+
+// @import 'shared/typography';
+// @import 'shared/tables';
+// @import 'shared/icons';
+// @import 'shared/forms';
+@import 'shared/layout';

--- a/app/assets/stylesheets/spree_admin.scss
+++ b/app/assets/stylesheets/spree_admin.scss
@@ -1,10 +1,11 @@
-// @import 'globals/functions';
-// @import 'globals/variables_override';
+@import 'globals/functions';
+@import 'globals/variables_override';
 @import 'globals/variables';
-// @import 'globals/mixins';
+@import 'globals/mixins';
 
-// @import 'shared/typography';
-// @import 'shared/tables';
-// @import 'shared/icons';
-// @import 'shared/forms';
+@import 'shared/typography';
+@import 'shared/tables';
+@import 'shared/icons';
 @import 'shared/layout';
+
+@import 'plugins/font-awesome';

--- a/app/views/variants_by_order/index.html.erb
+++ b/app/views/variants_by_order/index.html.erb
@@ -1,4 +1,4 @@
-<table>
+<table class="block-table">
   <thead>
     <tr>
       <th>Product</th>
@@ -11,9 +11,9 @@
 
   <% products_by_variant_id.each do |(variant_id, product)| %>
     <tr>
-      <td><%= product.first.name %> - Variant: <%= variant_id %></td>
+      <td class="align-center"><%= product.first.name %> - Variant: <%= variant_id %></td>
     <% orders_including_customer.each do |order| %>
-      <td><%= variants_by_order_report.line_item_for(variant_id, order.id) %></td>
+      <td class="align-center"><%= variants_by_order_report.line_item_for(variant_id, order.id) %></td>
     <% end %>
     </tr>
   <% end %>

--- a/app/views/variants_by_order/index.html.erb
+++ b/app/views/variants_by_order/index.html.erb
@@ -11,9 +11,9 @@
 
   <% products_by_variant_id.each do |(variant_id, product)| %>
     <tr>
-      <td class="align-center"><%= product.first.name %> - Variant: <%= variant_id %></td>
+      <td class="align-left"><%= product.first.name %> - Variant: <%= variant_id %></td>
     <% orders_including_customer.each do |order| %>
-      <td class="align-center"><%= variants_by_order_report.line_item_for(variant_id, order.id) %></td>
+      <td class="align-right"><%= variants_by_order_report.line_item_for(variant_id, order.id) %></td>
     <% end %>
     </tr>
   <% end %>

--- a/app/views/variants_by_order/index.html.erb
+++ b/app/views/variants_by_order/index.html.erb
@@ -10,7 +10,7 @@
   <tbody>
 
   <% products_by_variant_id.each do |(variant_id, product)| %>
-    <tr>
+    <tr class="<%= cycle("odd", "even") -%>">
       <td class="align-left"><%= product.first.name %> - Variant: <%= variant_id %></td>
     <% orders_including_customer.each do |order| %>
       <td class="align-right"><%= variants_by_order_report.line_item_for(variant_id, order.id) %></td>


### PR DESCRIPTION
Well, just that. As a first iteration I copied the styles I needed from Spree. Ideally we should use them from the gem itself, as it is in our Gemfile. That comes in https://github.com/coopdevs/katuma_reports/issues/5

Also, it would be better to use OFN's styles, which would include Spree's ones and OFN's overrides. This way the styling would be fully consistent. The problem here is that OFN it's not a gem we can add in the Gemfile.