### PR TITLE
I18n

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,4 +275,4 @@ RUBY VERSION
    ruby 2.1.5p273
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -4,7 +4,7 @@
     <div class="sixteen columns">
       <div class="block-table">
         <div class="table-cell">
-          <h1 class="page-title ">Reports</h1>
+          <h1 class="page-title "><%= t('.reports') %></h1>
         </div>
       </div>
     </div>
@@ -17,9 +17,9 @@
     <div id="content">
     <%= form_tag('/admin/reports/variants_by_order', method: 'get') do %>
       <%= field_set_tag(nil, class: 'no-border-top') do %>
-        <%= label_tag(:order_cycle_id, 'Order cycle') %>
+        <%= label_tag(:order_cycle_id, t('.order_cycle')) %>
         <%= select_tag('order_cycle_id', options_from_collection_for_select(order_cycles, 'id', 'name')) %>
-        <%= submit_tag('Submit') %>
+        <%= submit_tag(t('.submit')) %>
       <% end %>
     <% end %>
     </div>

--- a/app/views/variants_by_order/index.html.erb
+++ b/app/views/variants_by_order/index.html.erb
@@ -1,8 +1,8 @@
 <table class="block-table">
   <thead>
     <tr>
-      <th>Product</th>
-      <th>Units</th>
+      <th><%= t('.product') %></th>
+      <th><%= t('.units') %></th>
     <% orders_including_customer.each do |order| %>
       <th><%= order.customer.name %> - <%= order.number %></th>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module KatumaReports
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.default_locale = :es
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,12 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: "Hello world"
+  reports:
+    index:
+      reports: 'Reports'
+      order_cycle: 'Order cycle'
+      submit: 'Submit'
+  variants_by_order:
+    index:
+      product: 'Product'
+      units: 'Units'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,10 @@
+es:
+  reports:
+    index:
+      reports: 'Informes'
+      order_cycle: 'Ciclo de pedido'
+      submit: 'Buscar'
+  variants_by_order:
+    index:
+      product: 'Producto'
+      units: 'Unidades'

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -58,7 +58,7 @@ describe ReportsController do
         it 'lets the user render the report' do
           get :index
           expect(response.body).to include(
-            "<input name=\"commit\" type=\"submit\" value=\"Submit\" />"
+            "<input name=\"commit\" type=\"submit\" value=\"#{I18n.t('reports.index.submit')}\" />"
           )
         end
       end


### PR DESCRIPTION
This sets `es` as the default locale and provides the translated copies. I made so to be consistent with the OFN's locale. Once we have `ca` ready with all the copies translated it'll be easy to switch reports to it as well.

Also, might be confusing for users to have suddenly the reports in a different language. We need to avoid those as much as possible.