### PR TITLE
Match any report name to show the reports index

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ KatumaReports::Application.routes.draw do
 
   scope '/admin' do
     scope '/reports' do
-      get '/orders_and_fulfillment', controller: :reports, action: :index
+      get '/:report', controller: :reports, action: :index
 
       resources :variants_by_order, only: %i[index]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ KatumaReports::Application.routes.draw do
     scope '/reports' do
       resources :variants_by_order, only: %i[index]
 
+      # This will match any URL like /admin/reports/<report_name> not matched
+      # by any of the previous declarations. Remember that Rails evaluates the
+      # routes from top to bottom.
       get '/:report', controller: :reports, action: :index
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,9 @@ KatumaReports::Application.routes.draw do
 
   scope '/admin' do
     scope '/reports' do
-      get '/:report', controller: :reports, action: :index
-
       resources :variants_by_order, only: %i[index]
+
+      get '/:report', controller: :reports, action: :index
     end
   end
 end


### PR DESCRIPTION
This decouples the reports app from the particular report URL we
override in Nginx. This means then, that if we need to change that URL
again, it will require changing the nginx config only.

This is exactly what happened now. We have to change the report URL in https://github.com/coopdevs/katuma-provisioning/pull/4 but also here.