### PR TITLE
Fix routes

### DIFF
--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -15,7 +15,7 @@
 <div class="container">
   <div class="row">
     <div id="content">
-    <%= form_tag('/admin/reports/variants_by_order', method: 'get') do %>
+    <%= form_tag('/admin/reports/order_cycle_management/variants_by_order', method: 'get') do %>
       <%= field_set_tag(nil, class: 'no-border-top') do %>
         <%= label_tag(:order_cycle_id, t('.order_cycle')) %>
         <%= select_tag('order_cycle_id', options_from_collection_for_select(order_cycles, 'id', 'name')) %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ KatumaReports::Application.configure do
   # config.force_ssl = true
 
   # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -34,7 +34,7 @@ KatumaReports::Application.configure do
   # config.force_ssl = true
 
   # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,11 @@ KatumaReports::Application.routes.draw do
 
   scope '/admin' do
     scope '/reports' do
-      resources :variants_by_order, only: %i[index]
+      get '/order_cycle_management', controller: :reports, action: :index
 
-      # This will match any URL like /admin/reports/<report_name> not matched
-      # by any of the previous declarations. Remember that Rails evaluates the
-      # routes from top to bottom.
-      get '/:report', controller: :reports, action: :index
+      scope '/order_cycle_management' do
+        resources :variants_by_order, only: %i[index]
+      end
     end
   end
 end


### PR DESCRIPTION
When accessing the report after selecting an order cycle, the app was crashing with a 404. It turns out that this was because nginx couldn't find a matching location for `/admin/reports/variants_by_order`.

As we do we have a location block for `/admin/reports/order_cycle_management` (see https://github.com/coopdevs/katuma-provisioning/blob/master/roles/katuma_reports/templates/katuma_reports.conf.j2#L1 and https://github.com/coopdevs/katuma-provisioning/blob/master/katuma.yml#L26) by namespacing any report under that URL nginx will successfully point them to the katuma reports upstream.