### PR TITLE
Memoize line_items_by_variant_id to fix N+1

### DIFF
--- a/app/models/variants_by_order_report.rb
+++ b/app/models/variants_by_order_report.rb
@@ -101,7 +101,7 @@ class VariantsByOrderReport
   #
   # @return [Hash<Integer, Array<Spree:LineItem>>]
   def line_items_by_variant_id
-    line_items.group_by(&:variant_id)
+    @line_items_by_variant_id ||= line_items.group_by(&:variant_id)
   end
 
   # Gets the line items that belong to an order of the specified order cycle


### PR DESCRIPTION
Closes #12. Looks like that was what the method was meant to do but we never actually implemented it.

This obviously fixes an N+1 when fetching the line items associated to a particular variant. We reduce the N occurrences of:

```
SELECT variant_id, order_id, quantity
FROM "spree_line_items"
  INNER JOIN "spree_orders" ON "spree_orders"."id" = "spree_line_items"."order_id"
  INNER JOIN "order_cycles" ON "order_cycles"."id" = "spree_orders"."order_cycle_id"
  INNER JOIN "customers" ON "customers"."id" = "spree_orders"."customer_id"
WHERE "order_cycles"."id" = 1
  AND (spree_orders.state = 'complete')
GROUP BY customers.id, spree_line_items.variant_id, spree_line_items.order_id, spree_line_items.quantity
```

to a single one.